### PR TITLE
mp3 preview file conversion script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ yarn-error.log
 /_ide_helper.php
 /.phpstorm.meta.php
 /databasemodel.mwb.bak
+node_modules/
+tmp/

--- a/scripts/mp3/README.md
+++ b/scripts/mp3/README.md
@@ -1,0 +1,18 @@
+## mp3
+
+[BeatSaver Viewer]: https://supermedium.com/beatsaver-viewer
+
+Convert OGG to MP3 and store in storage for audio preview.
+For easy access to song file without unzipping and to
+support iOS / Safari on browser previewers (e.g.,
+[BeatSaver Viewer]).
+
+### Usage
+
+Built with Node, uses ffmpeg. From the root folder:
+
+```
+cd scripts/mp3
+npm install
+node index.js
+```

--- a/scripts/mp3/index.js
+++ b/scripts/mp3/index.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+const ffmpeg = require('fluent-ffmpeg');
+const fs = require('fs');
+const glob = require('glob');
+const path = require('path');
+const PQueue = require('p-queue');
+const unzip = require('extract-zip');
+
+const pResolve = path.resolve;
+
+const queue = new PQueue({autoStart: true, concurrency: 4});
+const songs = glob.sync('../../storage/app/public/songs/*');
+const TMP = pResolve(process.cwd(), './tmp');
+
+songs.forEach(songPath => {
+  const id = path.basename(songPath);
+
+  queue.add(() => new Promise((resolve, reject) => {
+    // Check if already converted.
+    if (glob.sync(pResolve(songPath, '*.mp3')).length) {
+      log(id, 'Skipping (already exists).');
+      resolve();
+      return;
+    }
+
+    // Check if song is deleted.
+    if (!glob.sync(pResolve(songPath, '*.zip')).length) {
+      log(id, 'Skipping (no ZIP found).');
+      resolve();
+      return;
+    }
+
+    // Unzip.
+    const unzipPath = pResolve(TMP, id);
+    unzip(glob.sync(pResolve(songPath, '*.zip'))[0], {dir: pResolve(TMP, id)}, err => {
+      if (err) {
+        log(id, `${err}`);
+        reject();
+        return;
+      }
+
+      // log(id, `Unzipped to ${unzipPath}`);
+      glob.sync(pResolve(unzipPath, '*.ogg')).forEach(oggPath => {
+        // Store in song directory as MP3.
+        const mp3Path = pResolve(
+          songPath,
+          path.basename(oggPath).replace(/.ogg$/, '.mp3'));
+
+        // Convert to MP3.
+        ffmpeg(oggPath)
+          .output(mp3Path)
+          .on('end', () => {
+            // Delete temporary unzip path.
+            fs.unlink(unzipPath, () => {});
+            log(id, `Success! ${queue.size} remaining.`);
+            resolve();
+          }).on('error', err => {
+            log(id, `Error converting ${e.msg}`);
+            reject();
+          }).run();
+      });
+    });
+  }));
+});
+
+// Wait for finish.
+queue.onIdle().then(() => {
+  console.log('Finished!');
+}).catch(console.error);
+
+function log (id, msg) {
+  console.log(`[${id}] ${msg}`);
+}

--- a/scripts/mp3/package.json
+++ b/scripts/mp3/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "beatsaver-mp3-convert",
+  "version": "1.0.0",
+  "description": "Convert audio files to MP3 for previewing.",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "extract-zip": "^1.6.7",
+    "fluent-ffmpeg": "^2.1.2",
+    "glob": "^7.1.3",
+    "p-queue": "^3.0.0"
+  }
+}


### PR DESCRIPTION
For retroactive conversions, alongside https://github.com/elliotttate/beatsaver-laravel/pull/73

## mp3

[BeatSaver Viewer]: https://supermedium.com/beatsaver-viewer

Convert OGG to MP3 and store in storage for audio preview.
For easy access to song file without unzipping and to
support iOS / Safari on browser previewers (e.g.,
[BeatSaver Viewer]).

### Usage

Built with Node, uses ffmpeg. From the root folder:

```
cd scripts/mp3
npm install
node index.js
```